### PR TITLE
fix Unpectly ends "Open Folder in container"  due to environment variable.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,9 +19,7 @@
 		// Mount docker socket for docker builds
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		// Use host network
-		"--network=host",
-		// Mount azure, git and docker config
-		"-v", "${env:HOME}${env:USERPROFILE}/.azure:/root/.azure"
+		"--network=host"
 	],
 
 	// Set *default* container specific settings.json values on container create.


### PR DESCRIPTION
I wonder that ${env:HOME} is for UNIX environment and ${env:USERPROFILE}. 
But some famous PowerShell scripts(example [posh-git](https://github.com/dahlbyk/posh-git) use env:HOME in order to imitate UNIX environment, "Open Folder in container" ends error.

This block is unnecessary because it is written for .azure, then I removed to fix this error.